### PR TITLE
Update CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', jruby ]
+        ruby: [ '3.0', '3.1', '3.2', '3.3', head, jruby ]
         gemfile: [ gemfiles/carrierwave-3.gemfile ]
         include:
-          - ruby: '3.2'
+          - ruby: '3.3'
             gemfile: gemfiles/carrierwave-2.gemfile
-          - ruby: '3.2'
+          - ruby: '3.3'
             gemfile: gemfiles/carrierwave-master.gemfile
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       S3_BUCKET_NAME: test-bucket
       S3_ACCESS_KEY: DummyAccessKey
@@ -33,7 +33,7 @@ jobs:
                    -v /tmp/data:/data \
                    -v /tmp/config:/root/.minio \
                    minio/minio server /data
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -46,11 +46,11 @@ jobs:
     name: RuboCop
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: '3.3'
           bundler-cache: true
       - name: Run check
         run: bundle exec rake rubocop


### PR DESCRIPTION
I just brought the GitHub testing workflow up to date:
- add Ruby 3.3 and head
- remove unmaintained Ruby versions (EOL) 2.5, 2.6 and 2.7
- use the latest available Ubuntu version
- use the latest actions/checkout version (v4)