### PR TITLE
Improve test CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', jruby ]
-        gemfile: [ gemfiles/carrierwave-3.gemfile ]
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
+        gemfile: [gemfiles/carrierwave-3.gemfile]
+        experimental: [false]
         include:
-          - ruby: '3.2'
+          - ruby: '3.4'
             gemfile: gemfiles/carrierwave-2.gemfile
-          - ruby: '3.2'
+            experimental: false
+          - ruby: '3.4'
             gemfile: gemfiles/carrierwave-master.gemfile
-    runs-on: ubuntu-20.04
+            experimental: false
+          - ruby: ruby-head
+            gemfile: gemfiles/carrierwave-3.gemfile
+            experimental: true
+          - ruby: jruby-head
+            gemfile: gemfiles/carrierwave-2.gemfile
+            experimental: false
+    runs-on: ubuntu-24.04
+    continue-on-error: ${{ matrix.experimental }}
     env:
       S3_BUCKET_NAME: test-bucket
       S3_ACCESS_KEY: DummyAccessKey
@@ -33,7 +43,7 @@ jobs:
                    -v /tmp/data:/data \
                    -v /tmp/config:/root/.minio \
                    minio/minio server /data
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -44,13 +54,13 @@ jobs:
 
   rubocop:
     name: RuboCop
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: '3.4'
           bundler-cache: true
       - name: Run check
         run: bundle exec rake rubocop

--- a/gemfiles/carrierwave-2.gemfile
+++ b/gemfiles/carrierwave-2.gemfile
@@ -3,5 +3,6 @@
 source 'https://rubygems.org'
 
 gem 'carrierwave', '~> 2.0'
+gem 'concurrent-ruby', '1.3.4' # Tests fail with 1.3.5 on Ruby 2.5 and 2.6
 
 gemspec path: '../'

--- a/gemfiles/carrierwave-3.gemfile
+++ b/gemfiles/carrierwave-3.gemfile
@@ -3,5 +3,6 @@
 source 'https://rubygems.org'
 
 gem 'carrierwave', '~> 3.0'
+gem 'concurrent-ruby', '1.3.4' # Tests fail with 1.3.5 on Ruby 2.5 and 2.6
 
 gemspec path: '../'

--- a/gemfiles/carrierwave-master.gemfile
+++ b/gemfiles/carrierwave-master.gemfile
@@ -3,5 +3,6 @@
 source 'https://rubygems.org'
 
 gem 'carrierwave', github: 'carrierwaveuploader/carrierwave'
+gem 'concurrent-ruby', '1.3.4' # Tests fail with 1.3.5 on Ruby 2.5 and 2.6
 
 gemspec path: '../'


### PR DESCRIPTION
The content is almost the same as PR#179.
I don't think it's necessary to forcibly bump the Ruby version supported by the Gem.
