### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ gem 'carrierwave-aws'
 ```
 
 Run the bundle command from your shell to install it:
+
 ```bash
 bundle install
 ```
@@ -72,6 +73,21 @@ CarrierWave.configure do |config|
   # config.aws_signer = -> (unsigned_url, options) do
   #   Aws::CF::Signer.sign_url(unsigned_url, options)
   # end
+
+  # Optional: Define custom options for S3 read operations.
+  # config.aws_read_options = {
+  #   if_modified_since: 1.day.ago # Example: Only retrieve files modified since yesterday
+  # }
+
+  # Optional: Define custom options for S3 write operations.
+  # config.aws_write_options = {
+  #   storage_class: 'STANDARD_IA' # Use infrequent access storage class
+  # }
+
+  # Optional: Set asset_host_public to true when you want to serve files through
+  # a CDN or other asset host that requires public URLs, but you don't want to
+  # set aws_acl to 'public-read' for all files.
+  # config.asset_host_public = true
 end
 ```
 ### Custom options for S3 endpoint
@@ -79,7 +95,7 @@ end
 If you are using a non-standard endpoint for S3 service (eg: Swiss-based Exoscale S3) you can override it like this
 
 ```ruby
-    config.aws_credentials[:endpoint] = 'my.custom.s3.service.com'
+  config.aws_credentials[:endpoint] = 'my.custom.s3.service.com'
 ```
 
 ### Custom options for AWS URLs
@@ -102,7 +118,7 @@ class MyUploader < Carrierwave::Uploader::Base
 end
 ```
 
-### Configure the role for bucket access 
+### Configure the role for bucket access
 
 The IAM role accessing the AWS bucket specified when configuring `CarrierWave` needs to be given access permissions to that bucket. Apart from the obvious permissions required depending on what you want to do (read, write, delete…), you need to grant the `s3:PutObjectAcl` permission ([a permission to manipulate single objects´ access permissions](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUTacl.html)) lest you receive an `AccessDenied` error. The policy for the role will look something like this:
 
@@ -133,14 +149,13 @@ specific line.
 
 ```ruby
 class MyUploader < Carrierwave::Uploader::Base
-  # Storage configuration within the uploader supercedes the global CarrierWave
+  # Storage configuration within the uploader supersedes the global CarrierWave
   # config, so adjust accordingly...
 
   # Choose what kind of storage to use for this uploader:
   # storage :file
   # storage :fog
   storage :aws
-
 
   # More comments below in your file....
 end


### PR DESCRIPTION
## What's changed

- Update README.md
  - Add usage for `aws_read_options`, `aws_write_options` and `asset_host_public`
  - Remove redundant spaces
  - Fix typo

Related: https://github.com/carrierwaveuploader/carrierwave-aws/issues/181